### PR TITLE
FIX Anchor refreshes app instead of navigating

### DIFF
--- a/source/Append.Blazor.Fast.Documentation/Examples/Anchor/Default.razor
+++ b/source/Append.Blazor.Fast.Documentation/Examples/Anchor/Default.razor
@@ -1,2 +1,2 @@
 ﻿<ExampleHeader Component="typeof(Anchor)" Example="@GetType()" />
-<Anchor href="#">Anchor</Anchor>
+<Anchor href="/">Anchor</Anchor>

--- a/source/Append.Blazor.Fast/Components/Anchor.cs
+++ b/source/Append.Blazor.Fast/Components/Anchor.cs
@@ -1,5 +1,8 @@
 ﻿using Append.Blazor.Fast.Core;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Web;
+using System;
 
 namespace Append.Blazor.Fast.Components
 {
@@ -8,13 +11,26 @@ namespace Append.Blazor.Fast.Components
     /// </summary>
     public class Anchor : FastComponent
     {
+        [Inject] public NavigationManager NavigationManager { get; set; }
         /// <inheritdoc />
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
             builder.OpenElement(0, $"{ThemeName}-anchor");
-            builder.AddMultipleAttributes(1, AdditionalAttributes);
-            builder.AddContent(2, ChildContent);
+            builder.AddAttribute(1, "onclick", EventCallback.Factory.Create<MouseEventArgs>(this, Navigate));
+            builder.AddEventPreventDefaultAttribute(2, "onclick", true);
+            builder.AddMultipleAttributes(3, AdditionalAttributes);
+            builder.AddContent(4, ChildContent);
             builder.CloseElement();
+        }
+        private void Navigate()
+        {
+            if (AdditionalAttributes is null)
+                return;
+
+            if (!AdditionalAttributes!.TryGetValue("href", out var href))
+                return;
+
+            NavigationManager.NavigateTo(Convert.ToString(href)!);
         }
     }
 }


### PR DESCRIPTION
This PR solves the issue with the `<Anchor>` component not being able to do client side routing. 
Forceload might be an issue here for external routing, but client-side is fine for now. We expect that the core Blazor library comes up with a fix for this.
However the user can still override if need be, by specifying a onclick and navigating himself.